### PR TITLE
rmvd hardcoded part before namespace

### DIFF
--- a/run/_templates/README.md.tmpl
+++ b/run/_templates/README.md.tmpl
@@ -7,7 +7,7 @@ Vision plugins require golang (https://go.dev) to be installed
 Install the plugin with
 
 ```
-go install github.com/vision-cli/{{.Namespace}}
+go install {{.Namespace}}
 ```
 
 You will now see the {{.Name}} plugin commands on the vision cli


### PR DESCRIPTION
There was a bug due to which the README.md was generated with a duplicated URL. 